### PR TITLE
fix: Linux stat compatibility for PROMPT.md timestamp check

### DIFF
--- a/cr
+++ b/cr
@@ -3310,8 +3310,14 @@ cmd_implement() {
     local template_file="$CR_DIR/templates/PROMPT-template.md"
     if [[ -f "$prompt_file" ]] && [[ -f "$template_file" ]]; then
         local prompt_time template_time
-        prompt_time=$(stat -f %m "$prompt_file" 2>/dev/null || stat -c %Y "$prompt_file" 2>/dev/null || echo 0)
-        template_time=$(stat -f %m "$template_file" 2>/dev/null || stat -c %Y "$template_file" 2>/dev/null || echo 0)
+        # Linux uses -c %Y, macOS uses -f %m (stat -f on Linux returns filesystem info, not file mtime)
+        if [[ "$(uname)" == "Darwin" ]]; then
+            prompt_time=$(stat -f %m "$prompt_file" 2>/dev/null || echo 0)
+            template_time=$(stat -f %m "$template_file" 2>/dev/null || echo 0)
+        else
+            prompt_time=$(stat -c %Y "$prompt_file" 2>/dev/null || echo 0)
+            template_time=$(stat -c %Y "$template_file" 2>/dev/null || echo 0)
+        fi
 
         if [[ "$template_time" -gt "$prompt_time" ]]; then
             log_warn "PROMPT.md is older than the template and may be missing recent improvements"


### PR DESCRIPTION
## Problem

On Linux, `stat -f %m` returns filesystem info (including a `File:` prefix) rather than file modification time. This caused an 'unbound variable' error when the output was used in a numeric comparison with `set -u` enabled.

The original code assumed `stat -f %m` would fail on Linux and fall back to `stat -c %Y`, but on Linux `stat -f` doesn't fail — it just returns different (filesystem) information.

## Fix

Detect the OS and use the appropriate stat flag:
- **macOS**: `stat -f %m` (modification time)
- **Linux**: `stat -c %Y` (modification time)

## Testing

Tested on Ubuntu 24.04 — `cr implement` now runs without the unbound variable error.